### PR TITLE
Use Clojars dep to resolve skipped coordinate bug

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,6 @@
 {:paths ["src/main"]
  :deps
- {io.github.clojure/tools.build {:git/tag "v0.9.6"
-                                 :git/sha "8e78bcc"}
+ {io.github.clojure/tools.build {:mvn/version "0.9.6"}
   slipset/deps-deploy           {:mvn/version "0.2.0"}}
  :aliases
  {:build  {:exec-fn com.yetanalytics.clojars-build/jar}


### PR DESCRIPTION
Switch from GitHub to Clojars/Maven dep for tools.build in order to address an issue where the dep is skipped when building the jar, causing tools.build to not be included as a transitive dep in downstream libs or apps.